### PR TITLE
Add class to match base theme specificity

### DIFF
--- a/src/gplu.scss
+++ b/src/gplu.scss
@@ -245,7 +245,7 @@ p{font-size:1.125em; } //!important;
     flex-direction: row;
     justify-content: space-between;
     transition: all 0.1s linear;
-    a{color:$grey;}
+    a.nav-link{color:$grey;}
 
 }
 


### PR DESCRIPTION
This fixes the issue of the navbar color not being applied because of an increase in specificity in master theme.